### PR TITLE
This either fixes naming issues or misses the point completely

### DIFF
--- a/geojson/schema.txt
+++ b/geojson/schema.txt
@@ -13,7 +13,7 @@ enum GeoJSONType {
 	FeatureCollection
 }
 
-enum GeoJSONCoordinateSystemType {
+enum GeoJSONCoordinateReferenceSystemType {
   name
   link
 }
@@ -48,49 +48,49 @@ interface GeoJSONGeometryInterface {
 
 type GeoJSONPoint implements GeoJSONInterface, GeoJSONGeometryInterface {
 	type: GeoJSONType!
-	crs: GeoJSONCoordinateSystem
+	crs: GeoJSONCoordinateReferenceSystem
 	bbox: [Float]
 	coordinates: GeoJSONCoordinates
 }
 
 type GeoJSONMultiPoint implements GeoJSONInterface, GeoJSONGeometryInterface {
 	type: GeoJSONType!
-	crs: GeoJSONCoordinateSystem
+	crs: GeoJSONCoordinateReferenceSystem
 	bbox: [Float]
 	coordinates: GeoJSONCoordinates
 }
 
 type GeoJSONLineString implements GeoJSONInterface, GeoJSONGeometryInterface {
 	type: GeoJSONType!
-	crs: GeoJSONCoordinateSystem
+	crs: GeoJSONCoordinateReferenceSystem
 	bbox: [Float]
 	coordinates: GeoJSONCoordinates
 }
 
 type GeoJSONMultiLineString implements GeoJSONInterface, GeoJSONGeometryInterface {
 	type: GeoJSONType!
-	crs: GeoJSONCoordinateSystem
+	crs: GeoJSONCoordinateReferenceSystem
 	bbox: [Float]
 	coordinates: GeoJSONCoordinates
 }
 
 type GeoJSONPolygon implements GeoJSONInterface, GeoJSONGeometryInterface {
 	type: GeoJSONType!
-	crs: GeoJSONCoordinateSystem
+	crs: GeoJSONCoordinateReferenceSystem
 	bbox: [Float]
 	coordinates: GeoJSONCoordinates
 }
 
 type GeoJSONMultiPolygon implements GeoJSONInterface, GeoJSONGeometryInterface {
 	type: GeoJSONType!
-	crs: GeoJSONCoordinateSystem
+	crs: GeoJSONCoordinateReferenceSystem
 	bbox: [Float]
 	coordinates: GeoJSONCoordinates
 }
 
 type GeoJSONGeometryCollection implements GeoJSONInterface {
 	type: GeoJSONType!
-	crs: GeoJSONCoordinateSystem
+	crs: GeoJSONCoordinateReferenceSystem
 	bbox: [Float]
 
 	geometries: [GeoJSONGeometryInterface!]!
@@ -98,7 +98,7 @@ type GeoJSONGeometryCollection implements GeoJSONInterface {
 
 type GeoJSONFeature implements GeoJSONInterface {
 	type: GeoJSONType!
-	crs: GeoJSONCoordinateSystem
+	crs: GeoJSONCoordinateReferenceSystem
 	bbox: [Float]
 
 	geometry: GeoJSONGeometryInterface
@@ -108,7 +108,7 @@ type GeoJSONFeature implements GeoJSONInterface {
 
 type GeoJSONFeatureCollection implements GeoJSONInterface {
 	type: GeoJSONType!
-	crs: GeoJSONCoordinateSystem
+	crs: GeoJSONCoordinateReferenceSystem
 	bbox: [Float]
 
 	features: [GeoJSONFeature!]!


### PR DESCRIPTION
With
apollo 0.8.0
graphql@0.9.6
graphql-tools@0.11.0

it would complain:

```
 (STDERR) Error: Type "GeoJSONCoordinateSystem" not found in document.
 (STDERR)     at typeDefNamed (node_modules/graphql/utilities/buildASTSchema.js:263:13)
 (STDERR)     at produceType (node_modules/graphql/utilities/buildASTSchema.js:233:19)
 (STDERR)     at produceOutputType (node_modules/graphql/utilities/buildASTSchema.js:242:46)
 (STDERR)     at node_modules/graphql/utilities/buildASTSchema.js:315:15
 (STDERR)     at node_modules/graphql/jsutils/keyValMap.js:36:31
 (STDERR)     at Array.reduce (native)                          
 (STDERR)     at keyValMap (node_modules/graphql/jsutils/keyValMap.js:35:15)
 (STDERR)     at makeFieldDefMap (node_modules/graphql/utilities/buildASTSchema.js:311:36)
 (STDERR)     at fields (node_modules/graphql/utilities/buildASTSchema.js:302:16)
 (STDERR)     at resolveThunk (node_modules/graphql/type/definition.js:159:40)
```

As I have only been using graphql for a couple of days I can't help but think that I am missing something fundamental - I am submitting this pull request in the hope of deeper enlightenment :)

Thank you so much for creating this schema in the first place! 